### PR TITLE
Update interp_convert.cc: Fix G52/G92 reset on M2/M30

### DIFF
--- a/src/emc/rs274ngc/interp_convert.cc
+++ b/src/emc/rs274ngc/interp_convert.cc
@@ -5224,8 +5224,11 @@ int Interp::convert_stop(block_pointer block,    //!< pointer to a block of RS27
     }
 
 /*10*/
+    // Clear active G92/G52 offset
+    SET_G92_OFFSET(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    settings->parameters[5210] = 0;
     if (settings->disable_g92_persistence)
-      // Clear G92/G52 offset
+      // Clear persistant G92/G52 offset values
       for (index=5210; index<=5219; index++)
           settings->parameters[index] = 0;
 


### PR DESCRIPTION
G52/G92 offsets should be deactivated on M2/M30 according to RS274NGC standard.

With the current code persistence will by default automatically activate G52/G92 offset on restart and leave G92/G52 active after M2/M30. 
The standard states that 'Persistence' means that the values will be stored on M2/M30, G52/G92 is deactivated and if necessary the offset can be restored using G92.3
![RS274NGC_m2](https://github.com/Sigma1912/linuxcnc/assets/46067220/f3608cdf-6533-428c-a0d0-bf0661513446)
 As Point 1 clearly states, M2/M30 should reset G92/G52 (like 92.2).

![Nist g92 3](https://github.com/Sigma1912/linuxcnc/assets/46067220/3e8f8f41-3a3c-41c5-b6a6-2c3bea4d02cc)

'Persistence' as handled by the ini entry [RS274NGC] 'DISABLE_G92_PERSISTENCE' is with regard to the current G52/G92 offset values being stored in the 'var' file. 

With this there no longer any need to warn about unexpected offsets on startup like this:
https://linuxcnc.org/docs/html/gcode/coordinates.html#sec:g52
![g92 note](https://github.com/Sigma1912/linuxcnc/assets/46067220/a0d3efd5-d70d-408d-ac3e-d4eeb8b5a4f7)
